### PR TITLE
SpectaDSL: object life time bug fix.

### DIFF
--- a/Specta/Specta/SpectaDSL.m
+++ b/Specta/Specta/SpectaDSL.m
@@ -52,11 +52,14 @@ void spt_itShouldBehaveLike_(NSString *fileName, NSUInteger lineNumber, NSString
 
         beforeEach(^{
           NSDictionary *blockData = dataBlock();
-          [dataDict removeAllObjects];
           [dataDict addEntriesFromDictionary:blockData];
         });
 
         block(dataDict);
+
+        afterEach(^{
+          [dataDict removeAllObjects];
+        });
 
         afterAll(^{
           dataDict = nil;


### PR DESCRIPTION
The dataDict is cleared beforeEach test, hence objects held by this
dictionary are not release after each test. Therefore add afterEach
block which clears the dataDict.