### PR TITLE
XCTestCase+Specta: properly report unhandled exceptions in tests.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,29 @@
+version: 2
+jobs:
+  build:
+    macos:
+      xcode: "9.4.0"
+
+    steps:
+      - checkout
+
+      - run:
+          name: Update submodules
+          command: git submodule update --init --recursive
+
+      - run:
+          name: Build and run tests
+          command: fastlane scan
+          environment:
+            SCAN_DEVICE: iPhone 8
+            SCAN_SCHEME: libSpecta-iOS
+
+      - store_test_results:
+          path: test_output
+ 
+      - store_artifacts:
+          path: test_output
+      
+      - store_artifacts:
+          path: ~/Library/Logs/scan
+          destination: scan-logs

--- a/Specta.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/Specta.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/Specta/Specta.xcodeproj/project.pbxproj
+++ b/Specta/Specta.xcodeproj/project.pbxproj
@@ -1004,11 +1004,6 @@
 			buildSettings = {
 				COMBINE_HIDPI_IMAGES = YES;
 				EXECUTABLE_PREFIX = lib;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(DEVELOPER_FRAMEWORKS_DIR)",
-					"$(DEVELOPER_DIR)/Platforms/MacOSX.platform/Developer/Library/Frameworks",
-				);
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"DEBUG=1",
 					"$(inherited)",
@@ -1027,11 +1022,6 @@
 			buildSettings = {
 				COMBINE_HIDPI_IMAGES = YES;
 				EXECUTABLE_PREFIX = lib;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(DEVELOPER_FRAMEWORKS_DIR)",
-					"$(DEVELOPER_DIR)/Platforms/MacOSX.platform/Developer/Library/Frameworks",
-				);
 				INFOPLIST_FILE = Specta/Info.plist;
 				MACOSX_DEPLOYMENT_TARGET = 10.8;
 				MTL_ENABLE_DEBUG_INFO = NO;
@@ -1045,10 +1035,6 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CLANG_ENABLE_CODE_COVERAGE = NO;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(DEVELOPER_DIR)/Platforms/iPhoneSimulator.platform/Developer/Library/Frameworks",
-				);
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"DEBUG=1",
 					"$(inherited)",
@@ -1068,10 +1054,6 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CLANG_ENABLE_CODE_COVERAGE = NO;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(DEVELOPER_DIR)/Platforms/iPhoneSimulator.platform/Developer/Library/Frameworks",
-				);
 				INFOPLIST_FILE = Specta/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
@@ -1117,6 +1099,11 @@
 				ENABLE_BITCODE = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(DEVELOPER_FRAMEWORKS_DIR)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+				);
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_NO_COMMON_BLOCKS = YES;
@@ -1176,6 +1163,11 @@
 				ENABLE_BITCODE = NO;
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(DEVELOPER_FRAMEWORKS_DIR)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+				);
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
@@ -1201,12 +1193,6 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(DEVELOPER_FRAMEWORKS_DIR)",
-					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
-					"$(DEVELOPER_DIR)/Platforms/MacOSX.platform/Developer/Library/Frameworks",
-				);
 				FRAMEWORK_VERSION = A;
 				INFOPLIST_FILE = Specta/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
@@ -1229,12 +1215,6 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(DEVELOPER_FRAMEWORKS_DIR)",
-					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
-					"$(DEVELOPER_DIR)/Platforms/MacOSX.platform/Developer/Library/Frameworks",
-				);
 				FRAMEWORK_VERSION = A;
 				INFOPLIST_FILE = Specta/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
@@ -1252,10 +1232,6 @@
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
 				COMBINE_HIDPI_IMAGES = YES;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(DEVELOPER_FRAMEWORKS_DIR)",
-					"$(inherited)",
-				);
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"DEBUG=1",
 					"$(inherited)",
@@ -1274,10 +1250,6 @@
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
 				COMBINE_HIDPI_IMAGES = YES;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(DEVELOPER_FRAMEWORKS_DIR)",
-					"$(inherited)",
-				);
 				INFOPLIST_FILE = SpectaTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
 				METAL_ENABLE_DEBUG_INFO = NO;
@@ -1296,12 +1268,6 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(DEVELOPER_FRAMEWORKS_DIR)",
-					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
-					"$(DEVELOPER_DIR)/Platforms/iPhoneSimulator.platform/Developer/Library/Frameworks",
-				);
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"DEBUG=1",
 					"$(inherited)",
@@ -1331,12 +1297,6 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"$(DEVELOPER_FRAMEWORKS_DIR)",
-					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
-					"$(DEVELOPER_DIR)/Platforms/iPhoneSimulator.platform/Developer/Library/Frameworks",
-				);
 				INFOPLIST_FILE = Specta/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
@@ -1358,10 +1318,6 @@
 			buildSettings = {
 				CLANG_ENABLE_CODE_COVERAGE = NO;
 				CLANG_ENABLE_MODULES = YES;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(SDKROOT)/Developer/Library/Frameworks",
-					"$(inherited)",
-				);
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"DEBUG=1",
 					"$(inherited)",
@@ -1382,10 +1338,6 @@
 			buildSettings = {
 				CLANG_ENABLE_CODE_COVERAGE = NO;
 				CLANG_ENABLE_MODULES = YES;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(SDKROOT)/Developer/Library/Frameworks",
-					"$(inherited)",
-				);
 				INFOPLIST_FILE = SpectaTests/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";

--- a/Specta/Specta.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/Specta/Specta.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/Specta/Specta.xcodeproj/xcshareddata/xcschemes/libSpecta-iOS.xcscheme
+++ b/Specta/Specta.xcodeproj/xcshareddata/xcschemes/libSpecta-iOS.xcscheme
@@ -28,7 +28,26 @@
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "E9536D0A1968D3EE003D1FBA"
+               BuildableName = "Specta-iOSTests.xctest"
+               BlueprintName = "Specta-iOSTests"
+               ReferencedContainer = "container:Specta.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "E917140819DF07D700921712"
+            BuildableName = "libSpecta.a"
+            BlueprintName = "libSpecta-iOS"
+            ReferencedContainer = "container:Specta.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
       <AdditionalOptions>
       </AdditionalOptions>
    </TestAction>

--- a/Specta/Specta/SPTSharedExampleGroups.m
+++ b/Specta/Specta/SPTSharedExampleGroups.m
@@ -63,12 +63,4 @@ BOOL initialized = NO;
   [SPTCurrentSpec recordFailureWithDescription:description inFile:filename atLine:lineNumber expected:expected];
 }
 
-- (void)_recordUnexpectedFailureWithDescription:(NSString *)description exception:(NSException *)exception {
-  [SPTCurrentSpec _recordUnexpectedFailureWithDescription:description exception:exception];
-}
-
-- (_XCTestCaseImplementation *)internalImplementation {
-  return [SPTCurrentSpec internalImplementation];
-}
-
 @end

--- a/Specta/Specta/SpectaDSL.m
+++ b/Specta/Specta/SpectaDSL.m
@@ -61,10 +61,6 @@ void spt_itShouldBehaveLike_(NSString *fileName, NSUInteger lineNumber, NSString
         afterEach(^{
           [dataDict removeAllObjects];
         });
-
-        afterAll(^{
-          dataDict = nil;
-        });
       });
     } else {
       NSDictionary *data = dictionaryOrBlock;

--- a/Specta/Specta/XCTest+Private.h
+++ b/Specta/Specta/XCTest+Private.h
@@ -29,13 +29,3 @@
 - (void)startObserving;
 
 @end
-
-@interface _XCTestCaseImplementation : NSObject
-@end
-
-@interface XCTestCase ()
-
-- (_XCTestCaseImplementation *)internalImplementation;
-- (void)_recordUnexpectedFailureWithDescription:(NSString *)description exception:(NSException *)exception;
-
-@end

--- a/Specta/Specta/XCTestCase+Specta.m
+++ b/Specta/Specta/XCTestCase+Specta.m
@@ -59,7 +59,10 @@
       return;
     }
   }
-  [self _recordUnexpectedFailureWithDescription:description exception:exception];
+
+  // We cannot associate the exception with a specific file and line, throw it as an unexpected
+  // error.
+  [exception raise];
 }
 
 @end

--- a/Specta/SpectaTests/FailingSpecTest.m
+++ b/Specta/SpectaTests/FailingSpecTest.m
@@ -25,7 +25,7 @@ SpecEnd
 - (void)testFailingSpec {
   foo = @"not foo";
   bar = @"not bar";
-  XCTestSuiteRun *result = RunSpec(_FailingSpecTestSpec);
+  XCTestRun *result = RunSpec(_FailingSpecTestSpec);
   assertEqual([result unexpectedExceptionCount], 0);
   assertEqual([result failureCount], 2);
   assertFalse([result hasSucceeded]);

--- a/Specta/SpectaTests/FocusedSpecTest.m
+++ b/Specta/SpectaTests/FocusedSpecTest.m
@@ -68,7 +68,7 @@ SpecEnd
 
 - (void)test_focused_specs_are_run_exclusively {
   [_FocusedSpecTestSpec spt_setDisabled:NO];
-  XCTestSuiteRun *result = RunSpec(_FocusedSpecTestSpec);
+  XCTestRun *result = RunSpec(_FocusedSpecTestSpec);
   [_FocusedSpecTestSpec spt_setDisabled:YES];
 
   assertEqual([result testCaseCount], 2);

--- a/Specta/SpectaTests/PendingSpecTest1.m
+++ b/Specta/SpectaTests/PendingSpecTest1.m
@@ -21,7 +21,7 @@ SpecEnd
 @implementation PendingSpecTest1
 
 - (void)testPendingSpec {
-  XCTestSuiteRun *result = RunSpec(_PendingSpecTest1Spec);
+  XCTestRun *result = RunSpec(_PendingSpecTest1Spec);
   assertEqual([result testCaseCount], 5);
   assertEqual([result unexpectedExceptionCount], 0);
   assertEqual([result failureCount], 0);

--- a/Specta/SpectaTests/PendingSpecTest2.m
+++ b/Specta/SpectaTests/PendingSpecTest2.m
@@ -27,7 +27,7 @@ SpecEnd
 @implementation PendingSpecTest2
 
 - (void)testPendingSpec {
-  XCTestSuiteRun *result = RunSpec(_PendingSpecTest2Spec);
+  XCTestRun *result = RunSpec(_PendingSpecTest2Spec);
   assertEqual([result testCaseCount], 12);
   assertEqual([result unexpectedExceptionCount], 0);
   assertEqual([result failureCount], 0);

--- a/Specta/SpectaTests/PendingSpecTest3.m
+++ b/Specta/SpectaTests/PendingSpecTest3.m
@@ -16,7 +16,7 @@ SpecEnd
 @implementation PendingSpecTest3
 
 - (void)testPendingSpec {
-  XCTestSuiteRun *result = RunSpec(_PendingSpecTest3Spec);
+  XCTestRun *result = RunSpec(_PendingSpecTest3Spec);
   assertEqual([result testCaseCount], 2);
   assertEqual([result unexpectedExceptionCount], 0);
   assertEqual([result failureCount], 0);

--- a/Specta/SpectaTests/PendingSpecTest4.m
+++ b/Specta/SpectaTests/PendingSpecTest4.m
@@ -18,7 +18,7 @@ SpecEnd
 @implementation PendingSpecTest4
 
 - (void)testPendingSpec {
-  XCTestSuiteRun *result = RunSpec(_PendingSpecTest4Spec);
+  XCTestRun *result = RunSpec(_PendingSpecTest4Spec);
   assertEqual([result testCaseCount], 1);
   assertEqual([result unexpectedExceptionCount], 0);
   assertEqual([result failureCount], 0);

--- a/Specta/SpectaTests/SharedExamplesTest1.m
+++ b/Specta/SpectaTests/SharedExamplesTest1.m
@@ -43,7 +43,7 @@ SpecEnd
 
 - (void)testSharedExamples {
   items = [[NSMutableArray alloc] init];
-  XCTestSuiteRun *result = RunSpec(_SharedExamplesTest1Spec);
+  XCTestRun *result = RunSpec(_SharedExamplesTest1Spec);
   assertEqual([result testCaseCount], 4);
   assertEqual([result unexpectedExceptionCount], 0);
   assertEqual([result failureCount], 0);

--- a/Specta/SpectaTests/SharedExamplesTest2.m
+++ b/Specta/SpectaTests/SharedExamplesTest2.m
@@ -53,7 +53,7 @@ SharedExamplesEnd
 - (void)testSharedExamples {
   foo = @"Not Foo";
   items = [[NSMutableArray alloc] init];
-  XCTestSuiteRun *result = RunSpec(_SharedExamplesTest2Spec);
+  XCTestRun *result = RunSpec(_SharedExamplesTest2Spec);
   assertEqual([result testCaseCount], 4);
   assertEqual([result unexpectedExceptionCount], 0);
   assertEqual([result failureCount], 1);

--- a/Specta/SpectaTests/SharedExamplesTest4.m
+++ b/Specta/SpectaTests/SharedExamplesTest4.m
@@ -2,7 +2,7 @@
 
 SpecBegin(_SharedExamplesTest4)
 
-__block __weak NSString *foo = nil;
+__block NSString *foo;
 
 beforeEach(^{
   foo = @"bar";
@@ -36,7 +36,7 @@ SharedExamplesEnd
 @implementation SharedExamplesTest4
 
 - (void)testSharedExamples {
-  XCTestSuiteRun *result = RunSpec(_SharedExamplesTest4Spec);
+  XCTestRun *result = RunSpec(_SharedExamplesTest4Spec);
   assertEqual([result testCaseCount], 2);
   assertEqual([result unexpectedExceptionCount], 0);
   assertEqual([result failureCount], 0);

--- a/Specta/SpectaTests/SharedExamplesTest5.m
+++ b/Specta/SpectaTests/SharedExamplesTest5.m
@@ -21,7 +21,7 @@ SpecEnd
 
 - (void)testSharedExamplesFailingIfCalledInsideAnItBlock {
   shouldInvokeItShouldBehaveLike = YES;
-  XCTestSuiteRun *result = RunSpec(_SharedExamplesTest5Spec);
+  XCTestRun *result = RunSpec(_SharedExamplesTest5Spec);
   assertEqual([result testCaseCount], 1);
   assertEqual([result unexpectedExceptionCount], 1);
   assertEqual([result failureCount], 0);

--- a/Specta/SpectaTests/SharedExamplesTest6.m
+++ b/Specta/SpectaTests/SharedExamplesTest6.m
@@ -20,7 +20,7 @@ SpecEnd
 
 - (void)testSharedExamplesFailingIfNonexistent {
   shouldInvokeItBehavesLike = YES;
-  XCTestSuiteRun *result = RunSpec(_SharedExamplesTest6Spec);
+  XCTestRun *result = RunSpec(_SharedExamplesTest6Spec);
   assertEqual([result testCaseCount], 1);
   assertEqual([result unexpectedExceptionCount], 1);
   assertEqual([result failureCount], 0);

--- a/Specta/SpectaTests/TestHelper.h
+++ b/Specta/SpectaTests/TestHelper.h
@@ -1,6 +1,8 @@
 #import <XCTest/XCTest.h>
 #import <Specta/Specta.h>
 
+#import "SpectaUtility.h"
+
 #if __IPHONE_OS_VERSION_MAX_ALLOWED >= 90000 || __MAC_OS_X_VERSION_MAX_ALLOWED >= 101100
 
 @interface XCTestObservationCenter (SPTTestSuspention)
@@ -22,13 +24,14 @@
 
 #define RunSpec(TestClass) RunSpecClass([TestClass class])
 
-XCTestSuiteRun *RunSpecClass(Class testClass);
+XCTestRun *RunSpecClass(Class testClass);
 
-#define assertTrue(expression)        XCTAssertTrue((expression), @"")
-#define assertFalse(expression)       XCTAssertFalse((expression), @"")
-#define assertNil(a1)                 XCTAssertNil((a1), @"")
-#define assertNotNil(a1)              XCTAssertNotNil((a1), @"")
-#define assertEqual(a1, a2)           XCTAssertEqual((a1), (a2), @"")
-#define assertEqualObjects(a1, a2)    XCTAssertEqualObjects((a1), (a2), @"")
-#define assertNotEqual(a1, a2)        XCTAssertNotEqual((a1), (a2), @"")
-#define assertNotEqualObjects(a1, a2) XCTAssertNotEqualObjects((a1), (a2), @"")
+#define assertTrue(expression)        assertWithCurrentSpec(XCTAssertTrue((expression), @""))
+#define assertFalse(expression)       assertWithCurrentSpec(XCTAssertFalse((expression), @""))
+#define assertNil(a1)                 assertWithCurrentSpec(XCTAssertNil((a1), @""))
+#define assertNotNil(a1)              assertWithCurrentSpec(XCTAssertNotNil((a1), @""))
+#define assertEqual(a1, a2)           assertWithCurrentSpec(XCTAssertEqual((a1), (a2), @""))
+#define assertEqualObjects(a1, a2)    assertWithCurrentSpec(XCTAssertEqualObjects((a1), (a2), @""))
+#define assertNotEqual(a1, a2)        assertWithCurrentSpec(XCTAssertNotEqual((a1), (a2), @""))
+#define assertNotEqualObjects(a1, a2) assertWithCurrentSpec(XCTAssertNotEqualObjects((a1), (a2), @""))
+#define assertWithCurrentSpec(...) do { SPTSpec *self = SPTCurrentSpec; __VA_ARGS__; } while (0)

--- a/Specta/SpectaTests/TestHelper.m
+++ b/Specta/SpectaTests/TestHelper.m
@@ -1,15 +1,59 @@
 #import "TestHelper.h"
 
-XCTestSuiteRun *RunSpecClass(Class testClass) {
-  __block XCTestSuiteRun *result;
+@interface XCTestObservationCenter (Redeclaration)
+- (id)observers;
+- (void)removeTestObserver:(id<XCTestObservation>)testObserver;
+@end
+
+@implementation XCTestObservationCenter (Suspension)
+
+- (void)spt_suspendObservationForBlock:(void (^)(void))block {
+  id originalObservers = [[self observers] copy];
+  NSMutableArray *suspendedObservers = [NSMutableArray new];
+
+  for (id observer in originalObservers) {
+    [suspendedObservers addObject:observer];
+
+    if ([self respondsToSelector:@selector(removeTestObserver:)]) {
+      [self removeTestObserver:observer];
+    }
+    else if ([[self observers] respondsToSelector:@selector(removeObject:)]) {
+      [[self observers] removeObject:observer];
+    }
+    else {
+      NSAssert(NO, @"unexpected type: unable to remove observers: %@", originalObservers);
+    }
+  }
+
+  @try {
+    block();
+  }
+  @finally {
+    for (id observer in suspendedObservers) {
+      if ([[self observers] respondsToSelector:@selector(addObject:)]) {
+        [[self observers] addObject:observer];
+      }
+      else if ([self respondsToSelector:@selector(addTestObserver:)]) {
+        [self addTestObserver:observer];
+      }
+    }
+  }
+}
+
+@end
+
+XCTestRun *RunSpecClass(Class testClass) {
+  __block XCTestRun *result;
 
 #if __IPHONE_OS_VERSION_MAX_ALLOWED >= 90000 || __MAC_OS_X_VERSION_MAX_ALLOWED >= 101100
   XCTestObservationCenter *observationCenter = [XCTestObservationCenter sharedTestObservationCenter];
 #else
   XCTestObservationCenter *observationCenter = [XCTestObservationCenter sharedObservationCenter];
 #endif
-  [observationCenter _suspendObservationForBlock:^{
-    result = (id)[(XCTestSuite *)[XCTestSuite testSuiteForTestCaseClass:testClass] run];
+  [observationCenter spt_suspendObservationForBlock:^{
+    XCTestSuite *testSuite = [XCTestSuite testSuiteForTestCaseClass:testClass];
+    [testSuite runTest];
+    result = testSuite.testRun;
   }];
 
   return result;

--- a/Specta/SpectaTests/UnexpectedExceptionTest.m
+++ b/Specta/SpectaTests/UnexpectedExceptionTest.m
@@ -41,7 +41,7 @@ SpecEnd
 - (void)testUnexpectedExceptionHandling {
   shouldRaiseException = YES;
 
-  XCTestSuiteRun *result = RunSpec(_UnexpectedExceptionTestSpec);
+  XCTestRun *result = RunSpec(_UnexpectedExceptionTestSpec);
   assertEqual([result failureCount], 0);
   assertEqual([result unexpectedExceptionCount], 1);
   assertFalse([result hasSucceeded]);


### PR DESCRIPTION
The previous `_recordUnexpectedFailureWithDescription:exception:` method
is no longer available in XCTest, causing an unrecognized selector
exception when sending it. This avoids using any private API for the
reporting (which seems to be unavailable anymore in any form, anyway).